### PR TITLE
Simplify and document aggressively.

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -4,33 +4,48 @@ extern crate tokio_line as line;
 extern crate env_logger;
 
 use futures::Future;
+use tokio::reactor::{Reactor};
 use tokio::Service;
 
 pub fn main() {
     env_logger::init().unwrap();
 
-    let addr = "127.0.0.1:12345".parse().unwrap();
+    // First thing we need is a Tokio reactor which watches all our sources (e.g. sockets,
+    // channels) for readiness and then makes sure our code is actually only called when there is
+    // something to do.
+    let reactor = Reactor::default().unwrap();
 
-    line::Server::new()
-        .bind(addr)
-        .serve(tokio::simple_service(|msg| {
+    // To actually give over control flow to the reactor, we call reactor.spawn() later. Tokio
+    // takes control of our program then, everything is asynchronous from there. To still
+    // communicate with the reactor we need a handle which we can clone at will.
+    let handle = reactor.handle();
+    reactor.spawn();
+
+    // This brings up our server. 
+    let addr = "127.0.0.1:12345".parse().unwrap();
+    line::serve(
+        handle.clone(),
+        addr, 
+        tokio::simple_service(|msg| {
             println!("GOT: {:?}", msg);
             Ok(msg)
         }))
         .unwrap();
 
+    // Now our client. We use the same reactor as for the server - usually though this would be
+    // done in a separate program most likely on a separate machine. 
+    let client = line::connect(handle, &addr).unwrap();
 
-    let client = line::Client::new()
-        .connect(&addr)
-        .unwrap();
-
+    // The connect call returns us a ClientHandle that allows us to use the 'Service' as a function
+    // - one that returns a future that we can 'await' on. 
     let resp = client.call("Hello".to_string());
     println!("RESPONSE: {:?}", await(resp));
 
     drop(client);
 }
 
-// Why this isn't in futures-rs, I do not know...
+// Blocks the execution of the current thread until the future is available. Why this isn't in
+// futures-rs, I do not know... 
 fn await<T: Future>(f: T) -> Result<T::Item, T::Error> {
     use std::sync::mpsc;
     let (tx, rx) = mpsc::channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,90 +7,24 @@ extern crate log;
 use tokio::{server, NewService};
 use tokio::io::{Readiness, Transport};
 use tokio::proto::pipeline;
-use tokio::reactor::{Reactor, ReactorHandle};
+use tokio::reactor::ReactorHandle;
 use std::{io, mem};
 use std::net::SocketAddr;
 
-/// Line transport
+/// Line transport. This is a pretty bare implementation of a Transport that is chunked into
+/// individual lines. The job of a transport is twofold:
+///
+/// 1) take the bytes that arrive on our 'inner' (e.g. socket) and chunk them down into frames as
+///    Transport::In.
+/// 2) take the frames as Transport::Out to send out and turn them into bytes. This allows for
+///    example for combining multiple frames into one TCP send.
+///
+/// The Service only deals in The magic here is that 'inner' must implement 'Readiness' - this allows it to play with Tokio's
+/// reactor.
 pub struct Line<T> {
     inner: T,
-    rd: Vec<u8>,
-    wr: io::Cursor<Vec<u8>>,
-}
-
-pub struct Server {
-    reactor: Option<ReactorHandle>,
-    addr: Option<SocketAddr>
-}
-
-pub struct Client {
-    reactor: Option<ReactorHandle>,
-}
-
-impl Server {
-    pub fn new() -> Server {
-        Server {
-            reactor: None,
-            addr: None,
-        }
-    }
-
-    pub fn bind(mut self, addr: SocketAddr) -> Self {
-        self.addr = Some(addr);
-        self
-    }
-
-    pub fn serve<T>(self, new_service: T) -> io::Result<()>
-        where T: NewService<Req = String, Resp = String, Error = io::Error> + Send + 'static,
-    {
-        let reactor = match self.reactor {
-            Some(r) => r,
-            None => {
-                let reactor = try!(Reactor::default());
-                let handle = reactor.handle();
-                reactor.spawn();
-                handle
-            },
-        };
-
-        let addr = self.addr.unwrap_or_else(|| "0.0.0.0:0".parse().unwrap());
-
-        try!(server::listen(&reactor, addr, move |stream| {
-            // Initialize the pipeline dispatch with the service and the line
-            // transport
-            let service = try!(new_service.new_service());
-            pipeline::Server::new(service, Line::new(stream))
-        }));
-
-        Ok(())
-    }
-}
-
-pub type ClientHandle = pipeline::ClientHandle<String, String, io::Error>;
-
-impl Client {
-    pub fn new() -> Client {
-        Client {
-            reactor: None,
-        }
-    }
-
-    pub fn connect(self, addr: &SocketAddr) -> io::Result<ClientHandle> {
-        let reactor = match self.reactor {
-            Some(r) => r,
-            None => {
-                let reactor = try!(Reactor::default());
-                let handle = reactor.handle();
-                reactor.spawn();
-                handle
-            },
-        };
-
-        let addr = addr.clone();
-
-        // Connect the client
-        Ok(pipeline::connect(&reactor, addr, |stream| Ok(Line::new(stream))))
-    }
+    read_buffer: Vec<u8>,
+    write_buffer: io::Cursor<Vec<u8>>,
 }
 
 impl<T> Line<T>
@@ -99,14 +33,42 @@ impl<T> Line<T>
     pub fn new(inner: T) -> Line<T> {
         Line {
             inner: inner,
-            rd: vec![],
-            wr: io::Cursor::new(vec![]),
+            read_buffer: vec![],
+            write_buffer: io::Cursor::new(vec![]),
         }
     }
 }
 
+impl<T> Readiness for Line<T>
+    where T: Readiness
+{
+    // Our transport is ready for reading whenever our 'inner'.
+    fn is_readable(&self) -> bool {
+        self.inner.is_readable()
+    }
+
+    // And ready for writing whenever inner is. Below we make sure that we always write everything
+    // out to 'inner' whenever it is ready, so our writing buf should always be empty when 'inner'
+    // is ready for writing and non-empty if it isn't.
+    fn is_writable(&self) -> bool {
+        let is_writable = self.write_buffer.position() == self.write_buffer.get_ref().len() as u64;
+
+        if !is_writable {
+            assert!(!self.inner.is_writable());
+        }
+
+        is_writable
+    }
+}
+
+/// This defines the chunks of our transport, i.e. the representation that the 'Service' deals
+/// with. In our case the received and send Frame are the same (Strings with io::Error as
+/// failures), but they could be different (for example HttpRequest for In and HttpResponse for
+/// Out).
 pub type Frame = pipeline::Frame<String, io::Error>;
 
+/// This is a bare-metal implementation of a Transport. We define our frames to be String when
+/// reading from the wire, that is 'In' and also String when writing to the wire.
 impl<T> Transport for Line<T>
     where T: io::Read + io::Write + Readiness
 {
@@ -116,9 +78,13 @@ impl<T> Transport for Line<T>
     /// Read a message from the `Transport`
     fn read(&mut self) -> io::Result<Option<Frame>> {
         loop {
-            if let Some(n) = self.rd.iter().position(|b| *b == b'\n') {
-                let tail = self.rd.split_off(n+1);
-                let mut line = mem::replace(&mut self.rd, tail);
+            // First, we check if our read buffer contains a new line - if that is the case, we
+            // have one new Frame for the Service to consume. We remove the line from the input
+            // buffer and this function will get called by Tokio soon again to see if there are
+            // more frames available.
+            if let Some(n) = self.read_buffer.iter().position(|b| *b == b'\n') {
+                let tail = self.read_buffer.split_off(n+1);
+                let mut line = mem::replace(&mut self.read_buffer, tail);
 
                 // Remove the new line
                 line.truncate(n);
@@ -128,48 +94,68 @@ impl<T> Transport for Line<T>
                     .map_err(|_| io::Error::new(io::ErrorKind::Other, "invalid string"));
             }
 
-            match self.inner.read_to_end(&mut self.rd) {
-                Ok(0) => return Ok(Some(pipeline::Frame::Done)),
-                Ok(_) => {}
+            // There was no full line in the input buffer - let's see if anything is on our
+            // 'inner'. 
+            match self.inner.read_to_end(&mut self.read_buffer) {
+                Ok(0) => {
+                    // The other side hang up - this transport is all done.
+                    // TODO(sirver): The use case of this is not entirely clear to me.
+                    return Ok(Some(pipeline::Frame::Done));
+                },
+                Ok(_) => {
+                    // Some data was read. The next round in the loop will try to parse it into a
+                    // line again.
+                }
                 Err(e) => {
+                    // This would block - i.e. there is no data on the socket. We signal Tokio that
+                    // there is right now no full frame available. It will try again the next time
+                    // our source signals readiness to read.
                     if e.kind() == io::ErrorKind::WouldBlock {
                         return Ok(None);
                     }
 
+                    // Just a regular error - pass upwards for handling.
                     return Err(e)
                 }
             }
         }
     }
 
-    /// Write a message to the `Transport`
+    /// Write a message to the `Transport`. This turns the frame we get into a byte string and adds
+    /// a newline. It then immediately gets flushed out to 'inner'.
     fn write(&mut self, req: Frame) -> io::Result<Option<()>> {
         match req {
             pipeline::Frame::Message(req) => {
                 trace!("writing value; val={:?}", req);
-                if self.wr.position() < self.wr.get_ref().len() as u64 {
+                // Our write buffer can only be non-empty if our 'inner' is not ready for writes.
+                // But since we signal to Tokio that our Transport is not ready when 'inner' is not
+                // ready it should never try to write to us as long as our write buffer is not
+                // empty.
+                if self.write_buffer.position() < self.write_buffer.get_ref().len() as u64 {
                     return Err(io::Error::new(io::ErrorKind::Other, "transport has pending writes"));
                 }
 
                 let mut bytes = req.into_bytes();
                 bytes.push(b'\n');
 
-                self.wr = io::Cursor::new(bytes);
+                self.write_buffer = io::Cursor::new(bytes);
                 self.flush()
             }
             _ => unimplemented!(),
         }
     }
 
-    /// Flush pending writes to the socket
+    /// Flush pending writes to the socket. This tries to write as much as possible of the data we
+    /// have in the write buffer to 'inner'. Since this might block - because inner is not ready,
+    /// we have to keep track of what we wrote.
     fn flush(&mut self) -> io::Result<Option<()>> {
         trace!("flushing transport");
         loop {
             // Making the borrow checker happy
             let res = {
                 let buf = {
-                    let pos = self.wr.position() as usize;
-                    let buf = &self.wr.get_ref()[pos..];
+                    let pos = self.write_buffer.position() as usize;
+                    let buf = &self.write_buffer.get_ref()[pos..];
 
                     if buf.is_empty() {
                         trace!("transport flushed");
@@ -186,8 +172,8 @@ impl<T> Transport for Line<T>
 
             match res {
                 Ok(mut n) => {
-                    n += self.wr.position() as usize;
-                    self.wr.set_position(n as u64)
+                    n += self.write_buffer.position() as usize;
+                    self.write_buffer.set_position(n as u64)
                 }
                 Err(e) => {
                     if e.kind() == io::ErrorKind::WouldBlock {
@@ -203,20 +189,23 @@ impl<T> Transport for Line<T>
     }
 }
 
-impl<T> Readiness for Line<T>
-    where T: Readiness
-{
-    fn is_readable(&self) -> bool {
-        self.inner.is_readable()
-    }
-
-    fn is_writable(&self) -> bool {
-        let is_writable = self.wr.position() == self.wr.get_ref().len() as u64;
-
-        if !is_writable {
-            assert!(!self.inner.is_writable());
-        }
-
-        is_writable
-    }
+/// Serve a service up. Secret sauce here is 'NewService', a helper that must be able to create a
+/// new 'Service' for each connection that we receive.
+pub fn serve<T>(reactor: ReactorHandle,  addr: SocketAddr, new_service: T) -> io::Result<()>
+    where T: NewService<Req = String, Resp = String, Error = io::Error> + Send + 'static {
+    try!(server::listen(&reactor, addr, move |stream| {
+        // Initialize the pipeline dispatch with the service and the line
+        // transport
+        let service = try!(new_service.new_service());
+        pipeline::Server::new(service, Line::new(stream))
+    }));
+    Ok(())
 }
+
+/// And the client: We use the same service, but this time we 'connect' instead of 'listen'.
+pub type ClientHandle = pipeline::ClientHandle<String, String, io::Error>;
+pub fn connect(reactor: ReactorHandle, addr: &SocketAddr) -> io::Result<ClientHandle> {
+    let addr = addr.clone();
+    Ok(pipeline::connect(&reactor, addr, |stream| Ok(Line::new(stream))))
+}
+


### PR DESCRIPTION
- Removes Client and Server and replaces them through flat functions
  that are easier to understand.
- Make reactor creation explicit to understand data flow in Tokio better
  while reading the example.
- Document the s**\* out of the code to make this a literal code walk
  that gets some of the core concepts of Tokio across in an easier to
  understand way.

This is an opinionated change: I think this repo should be a tutorial that is easy to follow and read. I therefore removed unneeded helper structs (Server & Client) and implicit reactor creation - the reactor is a core concept of tokio, it should be up and front in a tutorial. What do you think?
