### PR TITLE
Use `extend` instead of `extend_from_slice`

### DIFF
--- a/multiplexed/src/lib.rs
+++ b/multiplexed/src/lib.rs
@@ -196,8 +196,8 @@ impl Codec for LineCodec {
         let mut encoded_request_id = [0; 4];
         BigEndian::write_u32(&mut encoded_request_id, request_id as u32);
 
-        buf.extend_from_slice(&encoded_request_id);
-        buf.extend_from_slice(msg.as_bytes());
+        buf.extend(&encoded_request_id);
+        buf.extend(msg.as_bytes());
         buf.push(b'\n');
 
         Ok(())

--- a/simple/src/lib.rs
+++ b/simple/src/lib.rs
@@ -196,7 +196,7 @@ impl Codec for LineCodec {
     }
 
     fn encode(&mut self, msg: String, buf: &mut Vec<u8>) -> io::Result<()> {
-        buf.extend_from_slice(msg.as_bytes());
+        buf.extend(msg.as_bytes());
         buf.push(b'\n');
 
         Ok(())

--- a/streaming/src/lib.rs
+++ b/streaming/src/lib.rs
@@ -304,11 +304,11 @@ impl Codec for LineCodec {
                 // streaming body is an empty string.
                 assert!(message.is_empty() == body);
 
-                buf.extend_from_slice(message.as_bytes());
+                buf.extend(message.as_bytes());
             }
             Frame::Body { chunk } => {
                 if let Some(chunk) = chunk {
-                    buf.extend_from_slice(chunk.as_bytes());
+                    buf.extend(chunk.as_bytes());
                 }
             }
             Frame::Error { error } => {


### PR DESCRIPTION
These are identical since rust-lang/rust#37094 landed, and extend_from_slice will be deprecated in the future.

See also tokio-rs/website#49.