### PR TITLE
Track tokio-proto/generic-requestid

### DIFF
--- a/multiplexed/Cargo.toml
+++ b/multiplexed/Cargo.toml
@@ -8,7 +8,7 @@ log = "0.3.6"
 futures = "0.1"
 tokio-io = "0.1"
 tokio-core = "0.1"
-tokio-proto = "0.1"
+tokio-proto = { git = "https://github.com/koivunej/tokio-proto", branch = "generic-requestid" }
 tokio-service = "0.1"
 bytes = "0.4"
 

--- a/multiplexed/src/lib.rs
+++ b/multiplexed/src/lib.rs
@@ -218,6 +218,7 @@ impl Encoder for LineCodec {
 impl<T: AsyncRead + AsyncWrite + 'static> ClientProto<T> for LineProto {
     type Request = String;
     type Response = String;
+    type RequestId = u64;
 
     /// `Framed<T, LineCodec>` is the return value of `io.framed(LineCodec)`
     type Transport = Framed<T, LineCodec>;
@@ -231,6 +232,7 @@ impl<T: AsyncRead + AsyncWrite + 'static> ClientProto<T> for LineProto {
 impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for LineProto {
     type Request = String;
     type Response = String;
+    type RequestId = u64;
 
     /// `Framed<T, LineCodec>` is the return value of `io.framed(LineCodec)`
     type Transport = Framed<T, LineCodec>;


### PR DESCRIPTION
Hi there,

since I made the code changes already, I might as well open a pre-emptive PR on tokio-line. This PR modifies the `multiplexed` example for the breaking changes introduced in [the original PR for tokio-proto](https://github.com/tokio-rs/tokio-proto/pull/148) (one associated type per client or server).

**Do not merge yet** as this contains a `Cargo.toml` change for using the PR branch.